### PR TITLE
trim CNAME correctly

### DIFF
--- a/HappyDNS/Common/QNDnsManager.m
+++ b/HappyDNS/Common/QNDnsManager.m
@@ -64,7 +64,7 @@ static inline UInt32 bits_leadingZeros(UInt32 x) {
 static NSArray *trimCname(NSArray *records) {
 	NSMutableArray *array = [[NSMutableArray alloc] init];
 	for (QNRecord *r in records) {
-		if (r.type == kQNTypeA) {
+		if (r.type != kQNTypeCname) {
 			[array addObject:r];
 		}
 	}

--- a/HappyDNSTests/DnsTest.m
+++ b/HappyDNSTests/DnsTest.m
@@ -12,6 +12,7 @@
 #import "QNNetworkInfo.h"
 #import "QNDomain.h"
 #import "QNHijackingDetectWrapper.h"
+#import "QNDnspodFree.h"
 
 @interface DnsTest : XCTestCase
 
@@ -97,6 +98,12 @@
 	r = [dns queryWithDomain:domain];
 	XCTAssertEqual(r.count, 1, @"PASS");
 	XCTAssertFalse([@"3.3.3.3" isEqualToString:r[0]], @"PASS");
+}
+
+- (void) testHttpDNS {
+	QNDnsManager *dns = [[QNDnsManager alloc] init:@[[[QNDnspodFree alloc] init]] networkInfo:nil];
+	NSArray *ipArr = [dns query:@"www.github.com"];
+	XCTAssertTrue(ipArr.count > 0, @"PASS");
 }
 
 @end


### PR DESCRIPTION
看函数名应该是去掉 CNAME 记录。DNSPod 的 HTTP DNS Resolver 返回的记录用的 type 是 0（[QNDnspodFree.m](https://github.com/qiniu/happy-dns-objc/blob/76a1c85aa58d660f5824422cf826467f4cb6e71c/HappyDNS/Http/QNDnspodFree.m#L57) & [QNDnspodEnterprise](https://github.com/qiniu/happy-dns-objc/blob/76a1c85aa58d660f5824422cf826467f4cb6e71c/HappyDNS/Http/QNDnspodEnterprise.m#L113)），之前的代码会把它们剔除掉。